### PR TITLE
Add GitHub Actions Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+on:
+  push:
+    tags: ['v*']
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm test
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for automated npm publishing on tagged releases
- Workflow triggers on `v*` tags and publishes to npm registry
- Includes test validation before publishing and automatic GitHub release creation

## Test plan

- [x] Workflow file syntax is valid
- [x] All existing tests pass
- [ ] Test workflow execution when a version tag is pushed (will be validated in production)