### PR TITLE
Fix/release action GitHub release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-transclusion",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-transclusion",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "bin": {
         "markdown-transclusion": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:fix": "eslint src --ext .ts --fix",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist coverage",
+    "preversion": "git diff --quiet && git diff --cached --quiet && git branch --show-current | grep -q '^main$' || (echo 'Error: npm version requires clean main branch' && exit 1)",
     "prepublishOnly": "npm run clean && npm run build && npm test"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-transclusion",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Stream-based library for resolving Obsidian-style transclusion references in Markdown documents",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

Adds a pre-release config to `package.json` to enforce version bumps happen off a clean `main`.